### PR TITLE
Handle git-lfs authentication

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,7 @@ executed on the git server side are:
 - git-upload-pack (when the client does a git fetch or alike),
 - git-upload-archive (when the client does a git archive),
 - git-receive-pack (when the client does a git push or alike).
+- git-lfs-authenticate (when the client request authentication to a LFS backend)
 
 These three command are provided by this package and will act
 as a proxy between the mirror git server and the master git server.

--- a/bin/git-lfs-authenticate
+++ b/bin/git-lfs-authenticate
@@ -1,0 +1,1 @@
+git-mirror-cmd

--- a/scripts/git-mirror-cmd.sh
+++ b/scripts/git-mirror-cmd.sh
@@ -426,6 +426,19 @@ function mirror_upload() {
     fi
 }
 
+# Directly execute git-lfs-authenticate commands on remote
+function mirror_lfs_authenticate() {
+    local cmd="${1?}"
+    shift
+
+    read_config
+    check_config
+    log "INFO: exec: $ssh $ssh_opts -i$master_identity $master_user@$master_server $cmd $@"
+    "$ssh" $ssh_opts -i"$master_identity" "$master_user"@"$master_server" "$cmd" "$@"
+}
+
+
+
 # Direct call to git-mirror-cmd
 function mirror_cmd() {
     case "${1-}" in
@@ -458,6 +471,7 @@ case "$base" in
     git-receive-pack) mirror_receive "$base" "$@" ;;
     git-upload-pack) mirror_upload "$base" "$@" ;;
     git-upload-archive) mirror_upload "$base" "$@" ;;
+    git-lfs-authenticate) mirror_lfs_authenticate "$base" "$@" ;;
     git-mirror-cmd) mirror_cmd "$@" ;;
     *) fatal "unexpected base for $real_base: $base" ;;
 esac


### PR DESCRIPTION
This patch is for being able to use git-mirror for repos migrated on git-lfs.
The fix consists in handling the git-lfs-authenticate command in the git-mirror-cmd.sh script, by executing it on the git master server.
See https://github.com/git-lfs/git-lfs/blob/main/docs/api/authentication.md for further explanation.